### PR TITLE
feat: add Claude Opus 4.5 model

### DIFF
--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -264,6 +264,14 @@ class Pipe:
             "supports_memory": True,
             "supports_vision": True,
         },
+        "claude-opus-4-5-20251101": {
+            "max_tokens": 64000,
+            "context_length": 200000,
+            "supports_thinking": True,
+            "supports_1m_context": False,
+            "supports_memory": True,
+            "supports_vision": True,
+        },
         "claude-sonnet-4-5-20250929": {
             "max_tokens": 64000,
             "context_length": 200000,
@@ -293,6 +301,7 @@ class Pipe:
         "claude-sonnet-4": "claude-sonnet-4-20250514",
         "claude-opus-4": "claude-opus-4-20250514",
         "claude-opus-4-1": "claude-opus-4-1-20250805",
+        "claude-opus-4-5": "claude-opus-4-5-20251101",
         "claude-sonnet-4-5": "claude-sonnet-4-5-20250929",
         "claude-haiku-4-5": "claude-haiku-4-5-20251001",
     }


### PR DESCRIPTION
Introduced the "claude-opus-4-5-20251101" model with a maximum token limit of 64,000 and a context length of 200,000.

Opus 4.5 has a larger thinking budget than Opus 4.1.

- https://www.anthropic.com/news/claude-opus-4-5
- https://platform.claude.com/docs/en/about-claude/models/overview#latest-models-comparison