### PR TITLE
Add ANTHROPIC_BASE_URL valve for proxy/custom endpoint support

### DIFF
--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -701,6 +701,10 @@ class Pipe:
 
     class Valves(BaseModel):
         ANTHROPIC_API_KEY: str = "Your API Key Here"
+        ANTHROPIC_BASE_URL: str = Field(
+            default="",
+            description="Custom base URL for the Anthropic API (e.g. for a proxy). Leave empty to use the default Anthropic endpoint (https://api.anthropic.com).",
+        )
         ENABLE_FAST_MODE: bool = Field(
             default=False,
             description="Enable Fast Mode for Opus 4.6. Up to 2.5x faster output at higher costs",
@@ -928,7 +932,8 @@ class Pipe:
         models = []
         try:
             api_key = self.valves.ANTHROPIC_API_KEY
-            client = AsyncAnthropic(api_key=api_key)
+            base_url = self.valves.ANTHROPIC_BASE_URL.strip() or None
+            client = AsyncAnthropic(api_key=api_key, **({"base_url": base_url} if base_url else {}))
             async for m in client.models.list():
                 name = m.id
                 display_name = getattr(m, "display_name", name)
@@ -1395,7 +1400,8 @@ class Pipe:
             import hashlib
             import uuid
 
-            client = AsyncAnthropic(api_key=api_key)
+            base_url = self.valves.ANTHROPIC_BASE_URL.strip() or None
+            client = AsyncAnthropic(api_key=api_key, **({"base_url": base_url} if base_url else {}))
 
             # Get file metadata first
             file_meta = await client.beta.files.retrieve_metadata(file_id=file_id)
@@ -1473,7 +1479,8 @@ class Pipe:
         client = None
         try:
             from anthropic import AsyncAnthropic
-            client = AsyncAnthropic(api_key=self.valves.ANTHROPIC_API_KEY)
+            base_url = self.valves.ANTHROPIC_BASE_URL.strip() or None
+            client = AsyncAnthropic(api_key=self.valves.ANTHROPIC_API_KEY, **({"base_url": base_url} if base_url else {}))
         except ImportError:
             logger.warning("Anthropic SDK not available for file upload")
             return blocks_by_user_msg, processed_filenames
@@ -3167,7 +3174,8 @@ class Pipe:
                 api_key = user_api_key.strip()
                 logger.debug("Using user-provided API key from UserValves")
             request_timeout = self.valves.REQUEST_TIMEOUT
-            client = AsyncAnthropic(api_key=api_key, default_headers=headers, timeout=request_timeout)
+            base_url = self.valves.ANTHROPIC_BASE_URL.strip() or None
+            client = AsyncAnthropic(api_key=api_key, default_headers=headers, timeout=request_timeout, **({"base_url": base_url} if base_url else {}))
             payload_for_stream = {k: v for k, v in payload.items() if k != "stream"}
             include_usage = body.get("stream_options", {}).get("include_usage", False)
             if include_usage:
@@ -5112,7 +5120,8 @@ class Pipe:
             # Make synchronous request to Anthropic API
             # For task requests, we don't have __user__ context, so use default key
             api_key = self.valves.ANTHROPIC_API_KEY
-            client = AsyncAnthropic(api_key=api_key)
+            base_url = self.valves.ANTHROPIC_BASE_URL.strip() or None
+            client = AsyncAnthropic(api_key=api_key, **({"base_url": base_url} if base_url else {}))
 
             response = await client.messages.create(**task_payload)
 
@@ -6059,7 +6068,8 @@ class Pipe:
             try:
                 from anthropic import AsyncAnthropic
 
-                client = AsyncAnthropic(api_key=api_key)
+                base_url = self.valves.ANTHROPIC_BASE_URL.strip() or None
+                client = AsyncAnthropic(api_key=api_key, **({"base_url": base_url} if base_url else {}))
 
                 # Fetch all available skills
                 available_skills = {}

--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -4,7 +4,7 @@ id: anthropic_new
 author: Podden (https://github.com/Podden/)
 github: https://github.com/Podden/openwebui_anthropic_api_manifold_pipe
 original_author: Balaxxe (Updated by nbellochi)
-version: 0.8.11
+version: 0.8.12
 license: MIT
 requirements: pydantic>=2.0.0, anthropic>=0.75.0
 environment_variables:
@@ -37,6 +37,9 @@ Supports:
 - Programmatic Tool Calling (tools callable from code execution)
 
 Changelog:
+v0.8.12
+- Added ANTHROPIC_BASE_URL valve to allow routing all API requests through a custom proxy URL
+
 v0.8.11
 - Added Caching time CACHE_TTL valve to choose between 5 minutes (default) and 1 hour
 - Fixed TTS in Call Mode

--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -541,7 +541,12 @@ class PipeRequestContext:
 
 class Pipe:
     API_VERSION = "2023-06-01"  # Current API version as of May 2025
-    MODEL_URL = "https://api.anthropic.com/v1/messages"
+    _DEFAULT_API_BASE = "https://api.anthropic.com"
+
+    @property
+    def MODEL_URL(self):
+        base = self.valves.ANTHROPIC_BASE_URL.strip().rstrip("/") if hasattr(self, "valves") and self.valves.ANTHROPIC_BASE_URL.strip() else self._DEFAULT_API_BASE
+        return f"{base}/v1/messages"
 
     # Centralized model capabilities database
     # Note: Anthropic's /v1/models API only returns id, display_name, created_at, and type.


### PR DESCRIPTION
## Summary

- Adds a new `ANTHROPIC_BASE_URL` valve (default empty) that allows routing all Anthropic API calls through a custom base URL, e.g. a corporate proxy or local API gateway
- When left empty, behaviour is identical to before — the default `https://api.anthropic.com` endpoint is used
- Converts the previously unused hardcoded `MODEL_URL` class attribute to a `@property` that also respects the valve
- All six `AsyncAnthropic(...)` instantiation sites updated (model listing, file download, file upload, main streaming pipe, task requests, skills validation)