### PR TITLE
Add SHOW_CACHE_INFO user valve for displaying cache status

### DIFF
--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -852,6 +852,10 @@ class Pipe:
             default=False,
             description="Show Context Window Progress",
         )
+        SHOW_CACHE_INFO: bool = Field(
+            default=False,
+            description="Show cache status (write/read tokens) after each response. Immediately reveals when RAG, memory, or tool changes invalidate the cache.",
+        )
         WEB_SEARCH_MAX_USES: int = Field(
             default=5,
             ge=1,
@@ -3237,7 +3241,11 @@ class Pipe:
             base_url = self.valves.ANTHROPIC_BASE_URL.strip() or None
             client = AsyncAnthropic(api_key=api_key, default_headers=headers, timeout=request_timeout, **({"base_url": base_url} if base_url else {}))
             payload_for_stream = {k: v for k, v in payload.items() if k != "stream"}
-            include_usage = body.get("stream_options", {}).get("include_usage", False)
+            include_usage = (
+                __user__["valves"].SHOW_TOKEN_COUNT or
+                __user__["valves"].SHOW_CACHE_INFO or
+                body.get("stream_options", {}).get("include_usage", False)
+            )
             if include_usage:
                 total_usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}
                 if self.valves.CACHE_CONTROL != "cache disabled":
@@ -5121,21 +5129,7 @@ class Pipe:
 
         final_status = "✅ Response Complete"
         # ============ Token Count Display ============
-        if include_usage and __user__["valves"].SHOW_TOKEN_COUNT and total_usage:
-            # Use total_tokens from total_usage which now represents the last turn (Context Size)
-            total_tokens = total_usage.get("total_tokens", 0)
-
-            # Determine context window based on model capability and valve setting
-            model_info = self.get_model_info(body["model"].split("/")[-1])
-            is_1m = model_info.get("supports_1m_context", False)
-            context_window = 1_000_000 if is_1m else 200_000
-            context_label = "1M" if is_1m else "200k"
-            percentage = min((total_tokens / context_window) * 100, 100)
-
-            # Progress bar (10 segments)
-            filled = int(percentage / 10)
-            bar = "█" * filled + "░" * (10 - filled)
-
+        if include_usage and total_usage:
             def format_num(n: int) -> str:
                 if n >= 1_000_000:
                     return f"{n/1_000_000:.1f}M"
@@ -5143,9 +5137,38 @@ class Pipe:
                     return f"{n/1_000:.1f}K"
                 return str(n)
 
-            final_status += (
-                f" [{bar}] {format_num(total_tokens)}/{context_label} ({percentage:.1f}%)"
-            )
+            # Context window progress bar
+            if __user__["valves"].SHOW_TOKEN_COUNT:
+                # Use total_tokens from total_usage which now represents the last turn (Context Size)
+                total_tokens = total_usage.get("total_tokens", 0)
+
+                # Determine context window based on model capability and valve setting
+                model_info = self.get_model_info(body["model"].split("/")[-1])
+                is_1m = model_info.get("supports_1m_context", False)
+                context_window = 1_000_000 if is_1m else 200_000
+                context_label = "1M" if is_1m else "200k"
+                percentage = min((total_tokens / context_window) * 100, 100)
+
+                # Progress bar (10 segments)
+                filled = int(percentage / 10)
+                bar = "█" * filled + "░" * (10 - filled)
+
+                final_status += (
+                    f" [{bar}] {format_num(total_tokens)}/{context_label} ({percentage:.1f}%)"
+                )
+
+            # Cache status display
+            if (
+                __user__["valves"].SHOW_CACHE_INFO and
+                self.valves.CACHE_CONTROL != "cache disabled"
+            ):
+                ttl_label = "1hr" if self.valves.CACHE_TTL == "1 hour" else "5min"
+                cache_write = total_usage.get("cache_creation_input_tokens", 0)
+                cache_read = total_usage.get("cache_read_input_tokens", 0)
+                final_status += (
+                    f" | Cache write ({ttl_label}): {format_num(cache_write)}"
+                    f" | Cache read: {format_num(cache_read)}"
+                )
 
         # Consolidate: emit a final replace with the complete message so OpenWebUI
         # has the authoritative content (replaces any partial delta/replace state).


### PR DESCRIPTION
This PR resolves feature request #25 by adding a new user valve `SHOW_CACHE_INFO`. When enabled, each API response is preceded by the current read and write status of the remote prompt cache. For debuggability, the active cache TTL is also synopsized as either the substring `5min` or `1hr` depending on the value of the current system valve `CACHE_TTL`. Defaults to disabled. Pretend you want this. Pretend you're overjoyed, @podden.

The UI resembles:

<img width="1920" height="523" alt="Screenshot_cacheinfo_red" src="https://github.com/user-attachments/assets/75a42f79-41f2-43fe-bafd-0bea439f1290" />

I know what you're thinking. Actually... I don't. I'm only in my head. But what I *suspect* you might be thinking is:

> "Don't we already have the statistics under each message by clicking on the small 'i'? Pretty sure we don't need this. Two cache status user valves is one too many. CLOSED!"

I sympathize with those valid and justifiable complaints. :laughing: 

Sadly, the small 'i' doesn't really work for my use case. You have to explicitly hover over that thing (on desktop) or click that thing (on mobile) to get those statistics. And then you have to do that again... and again... and *again.* For every single conversation. Meanwhile, I just never do that. I forget. I get lazy. I start chatting and stop paying attention. Cache misses are *catastrophically* expensive, though – especially under Anthropic's new 1-hour TTL.

That's where this user valve comes in. It forcibly shoves the current cache status directly into my face. I don't have to hover over anything or click anything to see it. I don't have a choice, even. It's just *always* displayed. For deplorable people like me, that's a good thing.

If you still hate this, maybe we can tweak the UI a bit to make it less hateful to you. Oh, and...

## A Few Unrelated GitHub Tidbits

I noticed a mostly ignorable `git` merge conflict in the documentation:

```python
"""
...
Changelog:
v0.8.12
<<<<<<< main
- Added ANTHROPIC_BASE_URL valve to allow routing all API requests through a custom proxy URL
=======
- Fixed Tool Result output Grouping
- Decluddered the if/else horror in event_type handling
- Fixed OpenTerminal Tools
>>>>>>> main
...
"""
```

Would you like me to clean that up with this PR? On a similar topic of documentation, the human-readable description for the new wonderful `CACHE_TTL` valve you recently added doesn't quite seem right:

```python
        CACHE_TTL: Literal["5 minutes", "1 hour"] = Field(
            default="5 minutes",
            description="Cache time-to-live. 5 minutes is default Anthropic TTL; 1 hour requires no extra cost but keeps caches warm longer across conversations.",
        )
```

Pretty sure the 1 hour actually does [require extra cost](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pricing):

> If you find that 5 minutes is too short, Anthropic also offers a 1-hour cache duration [**at additional cost**](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pricing).

> For more information, see [1-hou r cache duration](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#1-hour-cache-duration).

Basically, the first hit against the 1-hour cache costs twice as much. It's almost always worth it, though, because each additional hit is just pennies. Would you like me to clean that up with this PR as well?

Lastly, I'd love to sponsor you via GitHub Sponsors. You do incredible work here. I want to support that work. When you find a moment, would you mind adding a `.github/SPONSORS.md` file to this repo?

## Thanks So Much! :smiling_face_with_three_hearts: 

You've already made my LLM life so much better. I appreciate all the wonderful open-source volunteerism you're doing here and elsewhere in the OpenWeb UI community. You rock! :man_singer: 