### PR TITLE
fix: remove duplicate x-api-key from default_headers to prevent 401

### DIFF
--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -7383,7 +7383,10 @@ class Pipe:
                 api_key = user_api_key.strip()
                 logger.debug("Using user-provided API key from UserValves")
             request_timeout = self.valves.REQUEST_TIMEOUT
-            client = self._build_anthropic_client(api_key, default_headers=headers, timeout=request_timeout)
+            # Strip x-api-key from default_headers: the SDK sets it internally from
+            # the api_key param; duplicating it causes 401 with SDK >= 0.100.
+            sdk_headers = {k: v for k, v in headers.items() if k.lower() != "x-api-key"}
+            client = self._build_anthropic_client(api_key, default_headers=sdk_headers, timeout=request_timeout)
             payload_for_stream = {k: v for k, v in payload.items() if k != "stream"}
             include_usage = (
                 __user__["valves"].SHOW_TOKEN_COUNT != "Off"


### PR DESCRIPTION
## Problem

With Anthropic SDK >= 0.100, the `pipe()` method triggers a **401 authentication_error** (`request_id: None`) on every request, even when the API key is valid.

## Root Cause

In `pipe()` (line ~7386), the headers dict — which already contains `x-api-key` — is passed as `default_headers` to `_build_anthropic_client()`, which also receives the key via `api_key=`. The SDK sets `x-api-key` internally from the `api_key` parameter. When the same header appears in `default_headers`, httpx merges them into a malformed multi-value header that Anthropic rejects.

**Reproducer:**
```python
from anthropic import AsyncAnthropic

# This fails with 401:
client = AsyncAnthropic(
    api_key="sk-ant-...",
    default_headers={"x-api-key": "sk-ant-..."}
)

# This works:
client = AsyncAnthropic(api_key="sk-ant-...")
```

## Fix

Strip `x-api-key` from the headers dict before passing it as `default_headers`, letting the SDK handle authentication via the `api_key` parameter alone. Other headers (`anthropic-version`, `content-type`, beta headers) are preserved.