### PR TITLE
Fix 401 "API key is invalid" by not passing x-api-key in the SDK's default_headers

### DIFF
--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -6498,6 +6498,11 @@ class Pipe:
 
         base_url = self.valves.ANTHROPIC_BASE_URL.strip() or None
         headers = dict(default_headers or {})
+        # The SDK derives the x-api-key header from api_key. A duplicate x-api-key in
+        # default_headers collides at the httpx layer (behavior varies by header casing)
+        # and corrupts the value → Anthropic 401 "API key is invalid". Strip any case
+        # variant so the SDK's own auth header is the only one sent.
+        headers = {k: v for k, v in headers.items() if k.lower() != "x-api-key"}
         ws_id = (getattr(self.valves, "ANTHROPIC_WORKSPACE_ID", "") or "").strip()
         if ws_id:
             headers.setdefault("anthropic-workspace-id", ws_id)


### PR DESCRIPTION
## Problem

Every request through the pipe fails with a 401, even with a valid API key:

```
Error code: 401 - {'type': 'error', 'error': {'type': 'authentication_error',
'message': 'API key is invalid.'}, 'request_id': None}
```

The same key works fine when used directly with the Anthropic SDK or via
OpenWebUI's native Anthropic connection, so the key itself is valid. The failure
is independent of the key value and reproduces across OpenWebUI versions.

## Root cause

The key is handed to the SDK **twice**:

- `_build_anthropic_client()` constructs `AsyncAnthropic(api_key=api_key)`, and the
  SDK derives its own `x-api-key` header from `api_key`.
- The same call also passes `default_headers=headers`, and that `headers` dict
  already contains an `x-api-key` entry (built in `_create_payload`).

The two `x-api-key` headers collide at the httpx layer and the header value gets
corrupted, so Anthropic rejects it as invalid.

## Reproduction

With a **valid** key:

```python
from anthropic import AsyncAnthropic
KEY = "sk-ant-..."  # a working key

# Works:
AsyncAnthropic(api_key=KEY)

# 401 "API key is invalid.":
AsyncAnthropic(
    api_key=KEY,
    default_headers={"x-api-key": KEY, "anthropic-version": "2023-06-01"},
)
```

Notably the behavior is casing-dependent (a same-cased duplicate corrupts, a
differently-cased one happens to normalize), which makes relying on the merge
behavior fragile. The SDK also does not accept `x-api-key` from `default_headers`
as auth at all — passing it there with an empty `api_key` raises
"Could not resolve authentication method" — so `api_key=` is the only supported
auth path.

## Fix

Strip any `x-api-key` variant from `default_headers` in `_build_anthropic_client()`,
so the SDK's own auth header (from `api_key`) is the only one sent. All client
creation routes through this method, so this covers every request path.

```python
headers = dict(default_headers or {})
# The SDK derives the x-api-key header from api_key. A duplicate x-api-key in
# default_headers collides at the httpx layer (behavior varies by header casing)
# and corrupts the value → Anthropic 401 "API key is invalid". Strip any case
# variant so the SDK's own auth header is the only one sent.
headers = {k: v for k, v in headers.items() if k.lower() != "x-api-key"}
```

Verified: after the change the same key authenticates successfully (`200`).