### PR TITLE
Bugfix: Follow Up Request Issue

### DIFF
--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -4661,6 +4661,34 @@ class Pipe:
                     all_matches.append((m.start(), "compaction", m))
 
                 if all_matches:
+                    # Pre-scan: build a map of standalone server_tool_result blocks
+                    # keyed by tool_use_id so each result can be emitted
+                    # IMMEDIATELY after its matching server_tool_use block —
+                    # even when text blocks or other tool_use blocks appear
+                    # between them in the stored HTML string.
+                    #
+                    # Without this fix, interleaved tool_use/tool_result blocks
+                    # (produced when the model calls multiple server tools in
+                    # rapid succession) are reconstructed in document order,
+                    # causing Anthropic API 400 errors on follow-up requests:
+                    # "tool use found without a corresponding tool_result block".
+                    _standalone_results: dict[str, dict] = {}
+                    for _, _kind, _m in all_matches:
+                        if _kind != "server_tool_result":
+                            continue
+                        _attrs_str = _m.group(1)
+                        _attrs = dict(PATTERN_DATA_ATTR.findall(_attrs_str))
+                        _pb64 = _attrs.get("payload-b64", "")
+                        _dec = (
+                            self._decode_block_payload(_pb64) if _pb64 else None
+                        )
+                        if isinstance(_dec, dict) and _dec.get(
+                            "type", ""
+                        ).endswith("_tool_result"):
+                            _tuid = _dec.get("tool_use_id", "")
+                            if _tuid:
+                                _standalone_results[_tuid] = _dec
+                    _consumed_results: set[str] = set()
                     all_matches.sort(key=lambda t: t[0])
                     blocks: list[dict] = []
                     last_end = 0
@@ -4697,17 +4725,52 @@ class Pipe:
                                 # emit it right after so the API sees the
                                 # full tool_use + tool_result pair at the
                                 # original position.
-                                # data-result-kind carries the block type (e.g. "web_search_tool_result")
-                                # and data-result-payload-b64 carries the encoded payload. The decoded
-                                # payload already has "type": "...", so result_kind is just sanity-check.
                                 result_b64 = attrs.get("result-payload-b64", "")
                                 if result_b64:
-                                    result_decoded = self._decode_block_payload(result_b64)
-                                    if (
-                                        isinstance(result_decoded, dict)
-                                        and result_decoded.get("type", "").endswith("_tool_result")
+                                    result_decoded = self._decode_block_payload(
+                                        result_b64
+                                    )
+                                    if isinstance(
+                                        result_decoded, dict
+                                    ) and result_decoded.get("type", "").endswith(
+                                        "_tool_result"
                                     ):
                                         blocks.append(result_decoded)
+                                        # Mark consumed so the standalone
+                                        # server_tool_result carrier is skipped
+                                        _tuid_emb = result_decoded.get(
+                                            "tool_use_id", ""
+                                        )
+                                        if _tuid_emb:
+                                            _consumed_results.add(_tuid_emb)
+                                else:
+                                    # No embedded result — look up the pre-scanned
+                                    # standalone result map and emit immediately
+                                    # to guarantee Anthropic-required adjacency:
+                                    # server_tool_use must be directly followed by
+                                    # its *_tool_result with nothing in between.
+                                    _tuid = decoded.get("id", "")
+                                    if _tuid and _tuid in _standalone_results:
+                                        blocks.append(_standalone_results[_tuid])
+                                        _consumed_results.add(_tuid)
+                                    elif _tuid:
+                                        logger.warning(
+                                            "server_tool_use id=%s has no matching "
+                                            "standalone result in pre-scan map — the "
+                                            "server_tool_result carrier may be missing "
+                                            "or PATTERN_SERVER_TOOL_RESULT_BLOCK failed "
+                                            "to match it. This tool_use will be emitted "
+                                            "without a result, which will cause a 400 on "
+                                            "the next follow-up request.",
+                                            _tuid,
+                                        )
+                                    else:
+                                        logger.warning(
+                                            "server_tool_use block has no 'id' field — "
+                                            "cannot look up standalone result in pre-scan "
+                                            "map. Block payload: %r",
+                                            decoded,
+                                        )
                             # else: legacy/missing payload → drop
                         elif kind == "server_tool_result":
                             attrs_str = match.group(1)
@@ -4715,7 +4778,11 @@ class Pipe:
                             payload_b64 = attrs.get("payload-b64", "")
                             decoded = self._decode_block_payload(payload_b64) if payload_b64 else None
                             if isinstance(decoded, dict) and decoded.get("type", "").endswith("_tool_result"):
-                                blocks.append(decoded)
+                                # Skip results already emitted immediately
+                                # after their server_tool_use block.
+                                _tuid = decoded.get("tool_use_id", "")
+                                if not _tuid or _tuid not in _consumed_results:
+                                    blocks.append(decoded)
                             # else: legacy/missing payload → drop
                         elif kind == "compaction":
                             blocks.append({


### PR DESCRIPTION
## Summary
After a complex Excel analysis involving multiple Anthropic-hosted code-execution calls, the next user message fails with an Anthropic API validation error.

The updated version of the Pipe function includes a fix for this issue.

## Steps to Reproduce the Issue
The issue can be reproduced reliably with our internal company data. Because that data is sensitive, the reproduction steps below use a public UK government dataset instead. _With the public dataset, the issue has been reproduced, but not on every attempt_.

### Environment
    • OpenWebUI version: v0.10.2
    • Anthropic Manifold Pipe version: 0.9.20
    • Model: claude-opus-4-8
    • Function calling mode: Native
    • Files API: Enabled
    • Skill: xlsx
    • Code Interpreter capability: Enabled
    • Dataset: UK Consumer Detriment Survey 2024
    • Dataset source: https://www.gov.uk/government/publications/consumer-detriment-survey-2024

### Setup
**1. Install the functions**
Add the following functions to OpenWebUI:
    • anthropic_manifold_companion_filter.py
    • anthropic_pipe.py
**2. Configure the Manifold Pipe valves**
Set the following valves to custom values:
    • Anthropic API Key
    • Anthropic Base URL
    • Enabled Models: claude-opus-4-8
Leave all other Manifold Pipe valves at their default values.
**3. Configure the model**
For the claude-opus-4-8 model, configure:
Advanced parameters
    • Function Calling: Native
Filters
    • anthropic_manifold_companion_filter
Capabilities
Enable:
    • File Upload
    • File Context
    • Code Interpreter
    • Status Updates
    • Built-in Tools
### Chat
**1. Start a new chat**
Open a new chat using the configured claude-opus-4-8 model.
**2. Configure the user valves**
Set:
    • Use Files API: Enabled
    • Skills: xlsx
Ensure that the Code Interpreter capability is attached to the chat.
**3. Download the public test files**
Download both XLSX workbooks published on the following page:
https://www.gov.uk/government/publications/consumer-detriment-survey-2024
Use the respondent-level and detriment-level Excel workbooks.
**4. Upload the files**
Upload both XLSX files to the chat.
Activate Full Context Mode for both files.
**5. Send the complex analysis request**
Send the following prompt:

> You are a senior consumer-insights analyst. Analyse both attached Excel workbooks from the UK Consumer Detriment Survey 2024.
> The respondent-level workbook and detriment-level workbook use different units of analysis. Inspect all relevant sheets and clearly distinguish between percentages of consumers, percentages of detriment experiences, weighted estimates, and unweighted base sizes.
> Create a comprehensive consumer-detriment funnel with the following conceptual stages:
>     1. Consumers who experienced at least one instance of detriment
>     2. Detriment experiences for which the consumer took action
>     3. Experiences where the consumer requested a remedy or resolution
>     4. Experiences where the seller or provider offered or supplied something
>     5. Experiences ending in a positive resolution
> Use the closest variables and tables available in the workbooks. Do not invent missing stages. Where two stages cannot be calculated directly from the published tables, explain the limitation and use the closest defensible measure.
> Perform the following analysis:
>     • Inspect the structure, sheet names, table headings, notes, bases, and definitions in both workbooks.
>     • Reconcile the respondent-level and detriment-level results.
>     • Calculate the conversion rate between each funnel stage and the cumulative conversion rate from the first to the final stage.
>     • Segment the funnel where possible by age, financial situation, disability or long-term health condition, country, purchase channel, and market sector.
>     • Identify the groups and sectors with the largest drop-offs.
>     • Compare actioned and unactioned detriment.
>     • Compare positive, neutral, and negative resolution outcomes.
>     • Examine financial impact, household-finance impact, mental-health impact, and physical-health impact.
>     • Flag estimates with small bases, suppressed values, incompatible denominators, or other methodological limitations.
>     • Cross-check all major figures against totals and base sizes in the workbooks.
>     • Identify any apparent discrepancies between the two workbooks and explain whether they arise from different units of analysis or definitions.
>     • Use Python and code execution to inspect and analyse the original Excel files. Do not rely only on visually reading extracted spreadsheet text.
> Return:
>     • An executive summary
>     • A funnel table with stage counts or percentages and conversion rates
>     • A segmentation table
>     • A market-sector risk table
>     • Key methodological cautions
>     • Five actionable conclusions for consumer-protection decision makers
> Show the source workbook, sheet, table, and base for every major result.

Allow the model to complete the analysis. The request should cause the model to perform several code-execution operations.

**6. Send a simple follow-up request**
After the analysis has completed, send:

> Please name a random number between 1 and 100.

## Actual behavior
The follow-up request fails with an error similar to:
```
Error: Invalid request format. Reason: Error code: 400 - {
  'type': 'error',
  'error': {
    'type': 'invalid_request_error',
    'message': 'messages.1: `bash_code_execution` tool use with id `<id>` was found without a corresponding `bash_code_execution_tool_result` block'
  },
  'request_id': 'req_<id>'
}
```
The exact tool-use ID and request ID vary between attempts.

## Expected behavior
The code-execution tool-use and tool-result blocks should be stored and reconstructed as matching pairs in the conversation history.

After the Excel analysis completes, a normal follow-up request should be sent successfully. 

## Diagnosis
The issue occurs when a text block is inserted between a bash_code_execution tool-use block and its corresponding bash_code_execution_tool_result block. Anthropic requires these related blocks to appear consecutively and therefore rejects the reconstructed conversation history as invalid.

The updated version of the Pipe function includes a fix that preserves the required ordering of code-execution tool-use and tool-result blocks.
