### PR TITLE
Add estimated turn cost to usage reports and status line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ The build works by marker pairs (`# BEGIN/END GENERATED SECTION: anthropic_pipe.
 | `src/anthropic_pipe/request/{cache_control,messages,tools,files,rag}.py` | `Pipe` method groups for the request half of a turn. |
 | `src/anthropic_pipe/response/*.py` | Response half: one module per Anthropic content-block family (`text_block`, `thinking_block`, `client_tool`, `server_tool`, `code_execution_results`, `web_tool_results`, `internal_tool_results`, `compaction_block`, `status_events`) plus `state`, `handlers`, `registry`, `runtime`, `formatting`. |
 | `src/anthropic_pipe/shared/{models,tasks}.py` | Model discovery/capabilities and OpenWebUI task handling (title, tags, follow-ups, memory review). |
+| `src/anthropic_pipe/shared/pricing.py` | Standalone `ModelPricing` class (module-level section, not a `Pipe` mixin): list-price table, `MODEL_PRICING_OVERRIDES` parsing, turn cost estimate. Anthropic exposes no prices via API, so the table is hand-maintained. |
 | `src/anthropic_pipe/pipe_orchestrator.py` | `Pipe.pipe()` request orchestration and the high-level tool loop. |
 | `helpers/build_anthropic_pipe.py` | Compiles `src/` into `anthropic_pipe.py`. |
 | `helpers/minify_pipe.py` | Strips comments/docstrings (keeps the module docstring OpenWebUI parses) for the upload artifact. |
@@ -58,6 +59,7 @@ Two module lists in `helpers/build_anthropic_pipe.py` are load-bearing:
 | Content-block streaming | `response/` — handlers are grouped by content type, not by Anthropic event type; `registry.py` wires them up |
 | Skills / tasks | `shared/tasks.py`, `request/files.py` → `_validate_and_get_skills` |
 | Formatting and persistence | `response/formatting.py`, `response/runtime.py` → `_format_thinking_block`, `_format_tool_result_block`, `_format_code_execution_block`, `_create_metadata_marker` |
+| Token usage and cost | `response/runtime.py` → `_handle_message_start_usage`, `_public_usage`; `shared/pricing.py` → `ModelPricing.estimate`. Private `_`-prefixed keys in `total_usage` (cache TTL split, fast/geo flags, web-search count) feed the estimate and are stripped before OpenWebUI sees the dict. |
 
 ## Invariants to preserve
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 📌 Current status
 
-- **Current pipe version:** `0.9.27`
+- **Current pipe version:** `0.9.28`
 - **Recommended OpenWebUI:** `0.11+` (works from `0.9.0+`)
 - **Minimum practical OpenWebUI for good UX:** `0.8.11+`
 - **Requirements:** `pydantic>=2.0.0`, `anthropic>=0.121.0`, `pillow-heif>=0.18.0`
@@ -125,6 +125,7 @@ If you fork this pipe or copy code into your own plugin, note that OpenWebUI `0.
 | `TOOL_CALL_TIMEOUT` | `30` | Per-tool execution timeout in seconds |
 | `ENABLE_CACHE_DIAGNOSTICS` | `false` | Logs cache-prefix diffs between turns. Debugging only |
 | `MODEL_CACHE_TTL_MINUTES` | `1440` | How long the discovered model list is cached (`0` = re-fetch on every model list render). Changing API key, base URL, workspace or `ENABLED_MODELS` refreshes immediately regardless |
+| `MODEL_PRICING_OVERRIDES` | `""` | JSON patch for the built-in price table behind `SHOW_COST`, in USD per million tokens keyed by model id, e.g. `{"claude-sonnet-5": {"input": 3, "output": 15}}`. Keys: `input`, `output`, `cache_write_5m`, `cache_write_1h`, `cache_read`, `fast_input`, `fast_output`; omitted cache rates derive from `input` at 1.25x / 2x / 0.1x. Anthropic publishes no prices through the API, so this is how to track price changes, negotiated rates or proxy models without a pipe release |
 
 #### `CACHE_CONTROL` options
 
@@ -148,6 +149,7 @@ If you fork this pipe or copy code into your own plugin, note that OpenWebUI `0.
 | `EFFORT` | `high` | `low`, `medium`, `high`, `xhigh`, `max` (clamped by model support; also settable via OpenWebUI's `reasoning_effort`) |
 | `HIDE_BLOCKS` | `[]` | Multiselect: block types to hide from the chat display while still replaying them to the API — `web_search`, `web_fetch`, `tool_search`, `advisor`, `code_execution`, `compaction` |
 | `SHOW_TOKEN_COUNT` | `Off` | `Off`, `On`, or `With Cache` (adds cache read/write tokens and call count) |
+| `SHOW_COST` | `true` | Reports the estimated USD list-price cost of the turn as `cost_usd` plus a per-component `cost_breakdown_usd` (`input`, `output`, `cache_write_5m`, `cache_write_1h`, `cache_read`, `web_search`) in the message usage (shown in the message info tooltip, persisted for analytics) and appends it to the `SHOW_TOKEN_COUNT` line (`💵 ≈$0.012`). Covers uncached input, output, 5m/1h cache writes, cache reads, fast mode, US data residency and web searches; models without a known rate card report nothing |
 | `TOOL_RESULT_MAX_TOKENS` | `50000` | Backstop truncation for oversized text tool results (`0` disables). Image blocks are exempt |
 
 #### Search, files, and skills
@@ -229,6 +231,10 @@ The API key valve — admin-wide and the per-user override — is encrypted befo
 ---
 
 ## 📝 Recent pipe changes
+### `v0.9.28`
+- Added an **estimated USD cost per turn** (new `SHOW_COST` user valve, on by default): reported as `cost_usd` plus a per-component `cost_breakdown_usd` in the message usage — so it shows in the message info tooltip and is persisted for the analytics page — and appended to the `SHOW_TOKEN_COUNT` status line. Anthropic exposes no pricing through the API — `/v1/models` carries capabilities and limits only — so prices come from a built-in list-price table; admins can patch or extend it without a release via the new `MODEL_PRICING_OVERRIDES` valve
+- The estimate follows the actual bill: cache writes are split 5m/1h from `usage.cache_creation`, fast mode and US data residency are read from the response `usage` (not from the valves that requested them), and web searches are added at $10 per 1,000
+
 ### `v0.9.27`
 - Fixed a follow-up request failing with `tool use found without a corresponding tool_result block` after a turn with several Anthropic-hosted code-execution calls. The stored carriers interleave once server tools run in quick succession, and replaying them in document order separated a `server_tool_use` from its result. Results are now pulled forward so the pair stays adjacent (#40, by @JaWoDigiB)
 - Fixed error notices and the File Content collapsible being swallowed into the preceding paragraph: code-execution / text-editor errors and safety refusals now go through the same own-line guarantee as every other rendered block (#46, by @Willian-Zhang)

--- a/anthropic_pipe.min.py
+++ b/anthropic_pipe.min.py
@@ -4,7 +4,7 @@ id: anthropic_new
 author: Podden (https://github.com/Podden/)
 github: https://github.com/Podden/openwebui_anthropic_api_manifold_pipe
 original_author: Balaxxe (Updated by nbellochi)
-version: 0.9.27
+version: 0.9.28
 license: MIT
 requirements: pydantic>=2.0.0, anthropic>=0.121.0, pillow-heif>=0.18.0
 environment_variables:
@@ -38,6 +38,10 @@ Supports:
 - Server-side fallback on safety refusals
 
 Changelog:
+v0.9.28
+- Added an estimated USD cost per turn (new SHOW_COST user valve): reported as `cost_usd` plus a per-component `cost_breakdown_usd` in the message usage, so it shows in the message info tooltip and is persisted for analytics, and appended to the SHOW_TOKEN_COUNT status line. Anthropic exposes no pricing via the API, so prices come from a built-in list-price table; admins can patch it without a release via the new MODEL_PRICING_OVERRIDES valve (JSON, USD per MTok)
+- The estimate follows the bill: cache writes are split 5m/1h from usage.cache_creation, fast mode and US data residency are detected from the response usage, and web searches are added at $10 per 1,000
+
 v0.9.27
 - Fixed model display names being lost while the model list is served from cache: the cached entries were built without the stored `_display_name`, so the picker fell back to raw ids for the whole cache TTL (#47, reported by @clang13)
 - Fixed a follow-up request 400 ("tool use found without a corresponding tool_result block") after a turn with several Anthropic-hosted code-execution calls: the stored carriers interleave, and replaying them in document order separated a server_tool_use from its result. Results are now pulled forward next to their tool_use (#40, by @JaWoDigiB)
@@ -2995,6 +2999,155 @@ async def handle_context_cleared_block_start(content_block: Any, ctx: Any) -> No
     await ctx.status.activity(status_desc)
     logger.debug("Context cleared: type=%s, tokens=%s", cleared_type, cleared_tokens)
 
+class ModelPricing:
+
+    RATES = {
+
+        "claude-fable-5-1": {"input": 10.0, "output": 50.0, "cache_read": 0.25},
+        "claude-mythos-5-1": {"input": 10.0, "output": 50.0, "cache_read": 0.25},
+        "claude-fable-5": {"input": 10.0, "output": 50.0},
+        "claude-mythos-5": {"input": 10.0, "output": 50.0},
+        "claude-opus-5": {"input": 5.0, "output": 25.0, "fast_input": 10.0, "fast_output": 50.0},
+        "claude-opus-4-8": {"input": 5.0, "output": 25.0, "fast_input": 10.0, "fast_output": 50.0},
+        "claude-opus-4-7": {"input": 5.0, "output": 25.0},
+        "claude-opus-4-6": {"input": 5.0, "output": 25.0},
+        "claude-opus-4-5": {"input": 5.0, "output": 25.0},
+        "claude-sonnet-5": {"input": 2.0, "output": 10.0},
+        "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
+        "claude-sonnet-4-5": {"input": 3.0, "output": 15.0},
+        "claude-haiku-4-5": {"input": 1.0, "output": 5.0},
+
+        "claude-opus-4-1": {"input": 15.0, "output": 75.0},
+        "claude-opus-4": {"input": 15.0, "output": 75.0},
+        "claude-sonnet-4": {"input": 3.0, "output": 15.0},
+        "claude-haiku-3-5": {"input": 0.8, "output": 4.0},
+        "claude-3-5-haiku": {"input": 0.8, "output": 4.0},
+    }
+
+    CACHE_WRITE_5M_MULTIPLIER = 1.25
+    CACHE_WRITE_1H_MULTIPLIER = 2.0
+    CACHE_READ_MULTIPLIER = 0.1
+
+    US_RESIDENCY_MULTIPLIER = 1.1
+
+    WEB_SEARCH_REQUEST_USD = 0.01
+
+    RATE_KEYS = (
+        "input",
+        "output",
+        "cache_write_5m",
+        "cache_write_1h",
+        "cache_read",
+        "fast_input",
+        "fast_output",
+    )
+
+    def __init__(self, overrides_json: str = ""):
+        self._overrides = self._parse_overrides(overrides_json)
+
+    @classmethod
+    def _parse_overrides(cls, raw: str) -> dict:
+        raw = (raw or "").strip()
+        if not raw:
+            return {}
+        try:
+            overrides = json.loads(raw)
+            if not isinstance(overrides, dict):
+                raise ValueError("top level must be an object keyed by model id")
+            parsed: dict = {}
+            for model_id, patch in overrides.items():
+                if not isinstance(patch, dict):
+                    raise ValueError(f"{model_id!r}: expected an object of rates")
+                parsed[model_id] = {
+                    k: float(v) for k, v in patch.items() if k in cls.RATE_KEYS and v is not None
+                }
+            return parsed
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Ignoring MODEL_PRICING_OVERRIDES: {e}")
+            return {}
+
+    @staticmethod
+    def _normalize(model_name: str) -> str:
+
+        return re.sub(r"-\d{8}$", "", model_name)
+
+    def rates_for(self, model_name: str) -> Optional[dict]:
+        normalized = self._normalize(model_name)
+        base = self.RATES.get(model_name) or self.RATES.get(normalized)
+        rates: dict = dict(base) if base else {}
+        patch = self._overrides.get(model_name) or self._overrides.get(normalized)
+        if patch:
+            rates.update(patch)
+
+        if "input" not in rates or "output" not in rates:
+            return None
+        rates.setdefault("cache_write_5m", rates["input"] * self.CACHE_WRITE_5M_MULTIPLIER)
+        rates.setdefault("cache_write_1h", rates["input"] * self.CACHE_WRITE_1H_MULTIPLIER)
+        rates.setdefault("cache_read", rates["input"] * self.CACHE_READ_MULTIPLIER)
+        return rates
+
+    @staticmethod
+    def record_billing_modifiers(usage: Any, total_usage: dict) -> None:
+        if not usage:
+            return
+        if getattr(usage, "speed", None) == "fast":
+            total_usage["_speed_fast"] = 1
+        if getattr(usage, "inference_geo", None) == "us":
+            total_usage["_geo_us"] = 1
+
+    def breakdown(self, model_name: str, total_usage: dict) -> Optional[dict]:
+        rates = self.rates_for(model_name)
+        if not rates:
+            return None
+
+        input_rate = rates["input"]
+        output_rate = rates["output"]
+        write_5m_rate = rates["cache_write_5m"]
+        write_1h_rate = rates["cache_write_1h"]
+        read_rate = rates["cache_read"]
+        if total_usage.get("_speed_fast") and "fast_input" in rates and "fast_output" in rates:
+            scale = rates["fast_input"] / input_rate if input_rate else 1.0
+            input_rate = rates["fast_input"]
+            output_rate = rates["fast_output"]
+            write_5m_rate *= scale
+            write_1h_rate *= scale
+            read_rate *= scale
+
+        write_5m = total_usage.get("_cache_write_5m", 0)
+        write_1h = total_usage.get("_cache_write_1h", 0)
+        if not write_5m and not write_1h:
+            write_5m = total_usage.get("cache_creation_input_tokens", 0)
+
+        geo = self.US_RESIDENCY_MULTIPLIER if total_usage.get("_geo_us") else 1.0
+        token_components = {
+            "input": total_usage.get("input_tokens", 0) * input_rate,
+            "output": total_usage.get("output_tokens", 0) * output_rate,
+            "cache_write_5m": write_5m * write_5m_rate,
+            "cache_write_1h": write_1h * write_1h_rate,
+            "cache_read": total_usage.get("cache_read_input_tokens", 0) * read_rate,
+        }
+        components = {
+            name: amount * geo / 1_000_000 for name, amount in token_components.items()
+        }
+        components["web_search"] = (
+            total_usage.get("_web_search_requests", 0) * self.WEB_SEARCH_REQUEST_USD
+        )
+        return {name: round(amount, 6) for name, amount in components.items() if amount}
+
+    def estimate(self, model_name: str, total_usage: dict) -> Optional[float]:
+        components = self.breakdown(model_name, total_usage)
+        if components is None:
+            return None
+        return round(sum(components.values()), 6)
+
+    @staticmethod
+    def format_usd(cost: float) -> str:
+        if cost >= 1:
+            return f"${cost:.2f}"
+        if cost >= 0.01:
+            return f"${cost:.3f}"
+        return f"${cost:.4f}"
+
 class Pipe:
     API_VERSION = "2023-06-01"
     _DEFAULT_API_BASE = "https://api.anthropic.com"
@@ -3280,6 +3433,16 @@ class Pipe:
             "Changing the API key, base URL, workspace or ENABLED_MODELS always "
             "refreshes immediately, regardless of this setting.",
         )
+        MODEL_PRICING_OVERRIDES: str = Field(
+            default="",
+            description="JSON patch for the built-in price table used by the SHOW_COST estimate, in USD per "
+            "million tokens, keyed by model id. Keys: input, output, cache_write_5m, cache_write_1h, "
+            "cache_read, fast_input, fast_output; omitted cache rates derive from `input` at Anthropic's "
+            "standard multipliers (1.25x / 2x / 0.1x). Example: "
+            '{"claude-sonnet-5": {"input": 3, "output": 15}, "my-proxy-model": {"input": 1, "output": 5}}. '
+            "Anthropic does not publish prices through the API, so this is how to track price changes "
+            "or a negotiated rate without waiting for a pipe release.",
+        )
 
     class UserValves(BaseModel):
         ANTHROPIC_API_KEY: EncryptedStr = Field(
@@ -3341,6 +3504,15 @@ class Pipe:
         SHOW_TOKEN_COUNT: Literal["Off", "On", "With Cache"] = Field(
             default="Off",
             description="Show context window progress after each response. 'With Cache' also shows cache read/write tokens.",
+        )
+        SHOW_COST: bool = Field(
+            default=True,
+            description="Report the estimated USD cost of the turn as `cost_usd` plus a per-component "
+            "`cost_breakdown_usd` (input, output, cache writes/reads, web search) in the message usage "
+            "(visible in the message info tooltip and persisted for analytics) and, when SHOW_TOKEN_COUNT "
+            "is on, in the status line. Based on Anthropic list prices for the model, including cache "
+            "writes/reads, fast mode, US data residency and web searches; negotiated or third-party-proxy "
+            "rates are not known to the pipe unless the admin sets MODEL_PRICING_OVERRIDES.",
         )
         WEB_SEARCH_MAX_USES: int = Field(
             default=5,
@@ -6637,6 +6809,9 @@ class Pipe:
         info.update(overrides)
         return info
 
+    def _model_pricing(self) -> "ModelPricing":
+        return ModelPricing(getattr(self.valves, "MODEL_PRICING_OVERRIDES", "") or "")
+
     def _model_cache_signature(self) -> str:
         parts = [
             (self.valves.ANTHROPIC_API_KEY or "").strip(),
@@ -7039,6 +7214,17 @@ class Pipe:
 
             total_usage["cache_creation_input_tokens"] += cache_creation_input_tokens
             total_usage["cache_read_input_tokens"] += cache_read_input_tokens
+
+            breakdown = getattr(usage, "cache_creation", None)
+            write_5m = getattr(breakdown, "ephemeral_5m_input_tokens", None) if breakdown else None
+            write_1h = getattr(breakdown, "ephemeral_1h_input_tokens", None) if breakdown else None
+            if write_5m is None and write_1h is None:
+                if self.valves.CACHE_TTL == "1 hour":
+                    write_1h = cache_creation_input_tokens
+                else:
+                    write_5m = cache_creation_input_tokens
+            total_usage["_cache_write_5m"] = total_usage.get("_cache_write_5m", 0) + (write_5m or 0)
+            total_usage["_cache_write_1h"] = total_usage.get("_cache_write_1h", 0) + (write_1h or 0)
             logger.debug(
                 f" Usage stats: input={input_tokens}, output={current_output_tokens}, "
                 f"cache_creation={cache_creation_input_tokens}, cache_read={cache_read_input_tokens}"
@@ -7049,6 +7235,7 @@ class Pipe:
             logger.debug(f" Usage stats: input={input_tokens}, output={current_output_tokens}")
 
         total_usage["_calls"] = total_usage.get("_calls", 0) + 1
+        ModelPricing.record_billing_modifiers(usage, total_usage)
 
         total_usage["_ctx_input"] = (
             input_tokens + cache_creation_input_tokens + cache_read_input_tokens
@@ -7730,6 +7917,7 @@ class Pipe:
                 tool_loop_iteration += 1
 
                 stream_output_tokens = 0
+                stream_web_search_requests = 0
 
                 try:
                     stream_event_counts = {}
@@ -7835,6 +8023,17 @@ class Pipe:
                                             total_usage.get("input_tokens", 0)
                                             + total_usage.get("output_tokens", 0)
                                         )
+
+                                        server_tool_use = getattr(usage, "server_tool_use", None)
+                                        current_searches = (
+                                            getattr(server_tool_use, "web_search_requests", 0) or 0
+                                        ) if server_tool_use else 0
+                                        total_usage["_web_search_requests"] = (
+                                            total_usage.get("_web_search_requests", 0)
+                                            + (current_searches - stream_web_search_requests)
+                                        )
+                                        stream_web_search_requests = current_searches
+                                        ModelPricing.record_billing_modifiers(usage, total_usage)
                                 delta = getattr(event, "delta", None)
                                 code_execution_container_id = getattr(delta, "container", None)
                                 if code_execution_container_id:
@@ -8409,6 +8608,12 @@ class Pipe:
 
         final_status = "✅ Response Complete"
 
+        if include_usage and total_usage and getattr(__user__["valves"], "SHOW_COST", True):
+            cost_breakdown = self._model_pricing().breakdown(body["model"].split("/")[-1], total_usage)
+            if cost_breakdown is not None:
+                total_usage["cost_usd"] = round(sum(cost_breakdown.values()), 6)
+                total_usage["cost_breakdown_usd"] = cost_breakdown
+
         show_token_setting = __user__["valves"].SHOW_TOKEN_COUNT
         if include_usage and show_token_setting != "Off" and total_usage and not is_internal:
             def format_num(n: int) -> str:
@@ -8452,6 +8657,9 @@ class Pipe:
 
                 if billed_input:
                     final_status += f" | ⚡ {cache_read / billed_input * 100:.0f}% cached"
+
+            if "cost_usd" in total_usage:
+                final_status += f" | 💵 ≈{ModelPricing.format_usd(total_usage['cost_usd'])}"
 
         if (
             getattr(self.valves, "ENABLE_CACHE_DIAGNOSTICS", False)

--- a/anthropic_pipe.py
+++ b/anthropic_pipe.py
@@ -4,7 +4,7 @@ id: anthropic_new
 author: Podden (https://github.com/Podden/)
 github: https://github.com/Podden/openwebui_anthropic_api_manifold_pipe
 original_author: Balaxxe (Updated by nbellochi)
-version: 0.9.27
+version: 0.9.28
 license: MIT
 requirements: pydantic>=2.0.0, anthropic>=0.121.0, pillow-heif>=0.18.0
 environment_variables:
@@ -38,6 +38,10 @@ Supports:
 - Server-side fallback on safety refusals
 
 Changelog:
+v0.9.28
+- Added an estimated USD cost per turn (new SHOW_COST user valve): reported as `cost_usd` plus a per-component `cost_breakdown_usd` in the message usage, so it shows in the message info tooltip and is persisted for analytics, and appended to the SHOW_TOKEN_COUNT status line. Anthropic exposes no pricing via the API, so prices come from a built-in list-price table; admins can patch it without a release via the new MODEL_PRICING_OVERRIDES valve (JSON, USD per MTok)
+- The estimate follows the bill: cache writes are split 5m/1h from usage.cache_creation, fast mode and US data residency are detected from the response usage, and web searches are added at $10 per 1,000
+
 v0.9.27
 - Fixed model display names being lost while the model list is served from cache: the cached entries were built without the stored `_display_name`, so the picker fell back to raw ids for the whole cache TTL (#47, reported by @clang13)
 - Fixed a follow-up request 400 ("tool use found without a corresponding tool_result block") after a turn with several Anthropic-hosted code-execution calls: the stored carriers interleave, and replaying them in document order separated a server_tool_use from its result. Results are now pulled forward next to their tool_use (#40, by @JaWoDigiB)
@@ -3444,6 +3448,171 @@ async def handle_context_cleared_block_start(content_block: Any, ctx: Any) -> No
     logger.debug("Context cleared: type=%s, tokens=%s", cleared_type, cleared_tokens)
 # END GENERATED SECTION: anthropic_pipe.response.internal_tool_results
 
+# BEGIN GENERATED SECTION: anthropic_pipe.shared.pricing
+class ModelPricing:
+    # Rate card in USD per million tokens, keyed by base (suffix-stripped) id.
+    # Source: platform.claude.com/docs/en/about-claude/pricing (verified
+    # 2026-09-02). The API does not expose pricing anywhere (/v1/models carries
+    # capabilities and limits only), so this table is the only source and the
+    # MODEL_PRICING_OVERRIDES valve is how admins patch it between releases.
+    #
+    # Only `input` and `output` are mandatory. The cache rates default to
+    # Anthropic's standard multipliers on the input price and are spelled out
+    # only where a model deviates. `fast_input` / `fast_output` are the
+    # fast-mode rates for the models that offer it.
+    RATES = {
+        # Cache reads on the 5.1 generation are 0.025x instead of 0.1x.
+        "claude-fable-5-1": {"input": 10.0, "output": 50.0, "cache_read": 0.25},
+        "claude-mythos-5-1": {"input": 10.0, "output": 50.0, "cache_read": 0.25},
+        "claude-fable-5": {"input": 10.0, "output": 50.0},
+        "claude-mythos-5": {"input": 10.0, "output": 50.0},
+        "claude-opus-5": {"input": 5.0, "output": 25.0, "fast_input": 10.0, "fast_output": 50.0},
+        "claude-opus-4-8": {"input": 5.0, "output": 25.0, "fast_input": 10.0, "fast_output": 50.0},
+        "claude-opus-4-7": {"input": 5.0, "output": 25.0},
+        "claude-opus-4-6": {"input": 5.0, "output": 25.0},
+        "claude-opus-4-5": {"input": 5.0, "output": 25.0},
+        "claude-sonnet-5": {"input": 2.0, "output": 10.0},
+        "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
+        "claude-sonnet-4-5": {"input": 3.0, "output": 15.0},
+        "claude-haiku-4-5": {"input": 1.0, "output": 5.0},
+        # Retired on the Claude API but still served by Bedrock / Google Cloud
+        # proxies. Haiku 3.5 is listed under both id orderings Anthropic used.
+        "claude-opus-4-1": {"input": 15.0, "output": 75.0},
+        "claude-opus-4": {"input": 15.0, "output": 75.0},
+        "claude-sonnet-4": {"input": 3.0, "output": 15.0},
+        "claude-haiku-3-5": {"input": 0.8, "output": 4.0},
+        "claude-3-5-haiku": {"input": 0.8, "output": 4.0},
+    }
+
+    # Multipliers relative to the base input price.
+    CACHE_WRITE_5M_MULTIPLIER = 1.25
+    CACHE_WRITE_1H_MULTIPLIER = 2.0
+    CACHE_READ_MULTIPLIER = 0.1
+    # `inference_geo: "us"` applies to every token category.
+    US_RESIDENCY_MULTIPLIER = 1.1
+    # Web search is billed per request on top of tokens ($10 per 1,000).
+    # Web fetch and code execution alongside web tools are free.
+    WEB_SEARCH_REQUEST_USD = 0.01
+
+    RATE_KEYS = (
+        "input",
+        "output",
+        "cache_write_5m",
+        "cache_write_1h",
+        "cache_read",
+        "fast_input",
+        "fast_output",
+    )
+
+    def __init__(self, overrides_json: str = ""):
+        self._overrides = self._parse_overrides(overrides_json)
+
+    @classmethod
+    def _parse_overrides(cls, raw: str) -> dict:
+        raw = (raw or "").strip()
+        if not raw:
+            return {}
+        try:
+            overrides = json.loads(raw)
+            if not isinstance(overrides, dict):
+                raise ValueError("top level must be an object keyed by model id")
+            parsed: dict = {}
+            for model_id, patch in overrides.items():
+                if not isinstance(patch, dict):
+                    raise ValueError(f"{model_id!r}: expected an object of rates")
+                parsed[model_id] = {
+                    k: float(v) for k, v in patch.items() if k in cls.RATE_KEYS and v is not None
+                }
+            return parsed
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Ignoring MODEL_PRICING_OVERRIDES: {e}")
+            return {}
+
+    @staticmethod
+    def _normalize(model_name: str) -> str:
+        # Endpoints without aliases hand out dated ids ("claude-opus-5-20260301").
+        return re.sub(r"-\d{8}$", "", model_name)
+
+    def rates_for(self, model_name: str) -> Optional[dict]:
+        normalized = self._normalize(model_name)
+        base = self.RATES.get(model_name) or self.RATES.get(normalized)
+        rates: dict = dict(base) if base else {}
+        patch = self._overrides.get(model_name) or self._overrides.get(normalized)
+        if patch:
+            rates.update(patch)
+
+        if "input" not in rates or "output" not in rates:
+            return None
+        rates.setdefault("cache_write_5m", rates["input"] * self.CACHE_WRITE_5M_MULTIPLIER)
+        rates.setdefault("cache_write_1h", rates["input"] * self.CACHE_WRITE_1H_MULTIPLIER)
+        rates.setdefault("cache_read", rates["input"] * self.CACHE_READ_MULTIPLIER)
+        return rates
+
+    @staticmethod
+    def record_billing_modifiers(usage: Any, total_usage: dict) -> None:
+        if not usage:
+            return
+        if getattr(usage, "speed", None) == "fast":
+            total_usage["_speed_fast"] = 1
+        if getattr(usage, "inference_geo", None) == "us":
+            total_usage["_geo_us"] = 1
+
+    def breakdown(self, model_name: str, total_usage: dict) -> Optional[dict]:
+        rates = self.rates_for(model_name)
+        if not rates:
+            return None
+
+        input_rate = rates["input"]
+        output_rate = rates["output"]
+        write_5m_rate = rates["cache_write_5m"]
+        write_1h_rate = rates["cache_write_1h"]
+        read_rate = rates["cache_read"]
+        if total_usage.get("_speed_fast") and "fast_input" in rates and "fast_output" in rates:
+            scale = rates["fast_input"] / input_rate if input_rate else 1.0
+            input_rate = rates["fast_input"]
+            output_rate = rates["fast_output"]
+            write_5m_rate *= scale
+            write_1h_rate *= scale
+            read_rate *= scale
+
+        # Cache writes split by TTL when the API reported the breakdown; the
+        # undifferentiated counter is the fallback for endpoints that do not.
+        write_5m = total_usage.get("_cache_write_5m", 0)
+        write_1h = total_usage.get("_cache_write_1h", 0)
+        if not write_5m and not write_1h:
+            write_5m = total_usage.get("cache_creation_input_tokens", 0)
+
+        geo = self.US_RESIDENCY_MULTIPLIER if total_usage.get("_geo_us") else 1.0
+        token_components = {
+            "input": total_usage.get("input_tokens", 0) * input_rate,
+            "output": total_usage.get("output_tokens", 0) * output_rate,
+            "cache_write_5m": write_5m * write_5m_rate,
+            "cache_write_1h": write_1h * write_1h_rate,
+            "cache_read": total_usage.get("cache_read_input_tokens", 0) * read_rate,
+        }
+        components = {
+            name: amount * geo / 1_000_000 for name, amount in token_components.items()
+        }
+        components["web_search"] = (
+            total_usage.get("_web_search_requests", 0) * self.WEB_SEARCH_REQUEST_USD
+        )
+        return {name: round(amount, 6) for name, amount in components.items() if amount}
+
+    def estimate(self, model_name: str, total_usage: dict) -> Optional[float]:
+        components = self.breakdown(model_name, total_usage)
+        if components is None:
+            return None
+        return round(sum(components.values()), 6)
+
+    @staticmethod
+    def format_usd(cost: float) -> str:
+        if cost >= 1:
+            return f"${cost:.2f}"
+        if cost >= 0.01:
+            return f"${cost:.3f}"
+        return f"${cost:.4f}"
+# END GENERATED SECTION: anthropic_pipe.shared.pricing
+
 class Pipe:
     API_VERSION = "2023-06-01"  # Current API version as of May 2025
     _DEFAULT_API_BASE = "https://api.anthropic.com"
@@ -3775,6 +3944,16 @@ class Pipe:
             "Changing the API key, base URL, workspace or ENABLED_MODELS always "
             "refreshes immediately, regardless of this setting.",
         )
+        MODEL_PRICING_OVERRIDES: str = Field(
+            default="",
+            description="JSON patch for the built-in price table used by the SHOW_COST estimate, in USD per "
+            "million tokens, keyed by model id. Keys: input, output, cache_write_5m, cache_write_1h, "
+            "cache_read, fast_input, fast_output; omitted cache rates derive from `input` at Anthropic's "
+            "standard multipliers (1.25x / 2x / 0.1x). Example: "
+            '{"claude-sonnet-5": {"input": 3, "output": 15}, "my-proxy-model": {"input": 1, "output": 5}}. '
+            "Anthropic does not publish prices through the API, so this is how to track price changes "
+            "or a negotiated rate without waiting for a pipe release.",
+        )
 
     class UserValves(BaseModel):
         ANTHROPIC_API_KEY: EncryptedStr = Field(
@@ -3843,6 +4022,15 @@ class Pipe:
         SHOW_TOKEN_COUNT: Literal["Off", "On", "With Cache"] = Field(
             default="Off",
             description="Show context window progress after each response. 'With Cache' also shows cache read/write tokens.",
+        )
+        SHOW_COST: bool = Field(
+            default=True,
+            description="Report the estimated USD cost of the turn as `cost_usd` plus a per-component "
+            "`cost_breakdown_usd` (input, output, cache writes/reads, web search) in the message usage "
+            "(visible in the message info tooltip and persisted for analytics) and, when SHOW_TOKEN_COUNT "
+            "is on, in the status line. Based on Anthropic list prices for the model, including cache "
+            "writes/reads, fast mode, US data residency and web searches; negotiated or third-party-proxy "
+            "rates are not known to the pipe unless the admin sets MODEL_PRICING_OVERRIDES.",
         )
         WEB_SEARCH_MAX_USES: int = Field(
             default=5,
@@ -8034,6 +8222,10 @@ class Pipe:
         info.update(overrides)
         return info
 
+    def _model_pricing(self) -> "ModelPricing":
+        """Rate card for this pipe, with the admin's MODEL_PRICING_OVERRIDES applied."""
+        return ModelPricing(getattr(self.valves, "MODEL_PRICING_OVERRIDES", "") or "")
+
     def _model_cache_signature(self) -> str:
         """Fingerprint of the settings the model list depends on.
 
@@ -8585,6 +8777,21 @@ class Pipe:
             # continuations (server tools such as web_search) and retries.
             total_usage["cache_creation_input_tokens"] += cache_creation_input_tokens
             total_usage["cache_read_input_tokens"] += cache_read_input_tokens
+            # 5m and 1h writes are billed at 1.25x and 2x respectively, so the
+            # cost estimate needs the split. The API reports it in
+            # `cache_creation`; without it, attribute the whole write to the
+            # configured TTL (loses precision only when the tools/system TTL
+            # differs from the messages TTL).
+            breakdown = getattr(usage, "cache_creation", None)
+            write_5m = getattr(breakdown, "ephemeral_5m_input_tokens", None) if breakdown else None
+            write_1h = getattr(breakdown, "ephemeral_1h_input_tokens", None) if breakdown else None
+            if write_5m is None and write_1h is None:
+                if self.valves.CACHE_TTL == "1 hour":
+                    write_1h = cache_creation_input_tokens
+                else:
+                    write_5m = cache_creation_input_tokens
+            total_usage["_cache_write_5m"] = total_usage.get("_cache_write_5m", 0) + (write_5m or 0)
+            total_usage["_cache_write_1h"] = total_usage.get("_cache_write_1h", 0) + (write_1h or 0)
             logger.debug(
                 f" Usage stats: input={input_tokens}, output={current_output_tokens}, "
                 f"cache_creation={cache_creation_input_tokens}, cache_read={cache_read_input_tokens}"
@@ -8595,6 +8802,7 @@ class Pipe:
             logger.debug(f" Usage stats: input={input_tokens}, output={current_output_tokens}")
 
         total_usage["_calls"] = total_usage.get("_calls", 0) + 1
+        ModelPricing.record_billing_modifiers(usage, total_usage)
 
         # Two different questions, deliberately kept apart:
         #
@@ -9442,6 +9650,7 @@ class Pipe:
                 tool_loop_iteration += 1
                 # Reset per-iteration state
                 stream_output_tokens = 0
+                stream_web_search_requests = 0
 
                 try:
                     stream_event_counts = {}  # Track event types for diagnostics#
@@ -9581,6 +9790,20 @@ class Pipe:
                                             total_usage.get("input_tokens", 0)
                                             + total_usage.get("output_tokens", 0)
                                         )
+                                        # Web searches are billed per request
+                                        # ($10/1k). Like output_tokens, the
+                                        # count is cumulative within one API
+                                        # call, so accumulate the delta.
+                                        server_tool_use = getattr(usage, "server_tool_use", None)
+                                        current_searches = (
+                                            getattr(server_tool_use, "web_search_requests", 0) or 0
+                                        ) if server_tool_use else 0
+                                        total_usage["_web_search_requests"] = (
+                                            total_usage.get("_web_search_requests", 0)
+                                            + (current_searches - stream_web_search_requests)
+                                        )
+                                        stream_web_search_requests = current_searches
+                                        ModelPricing.record_billing_modifiers(usage, total_usage)
                                 delta = getattr(event, "delta", None)
                                 code_execution_container_id = getattr(delta, "container", None)
                                 if code_execution_container_id:
@@ -10262,6 +10485,17 @@ class Pipe:
         # ---------------------------------------------------------
 
         final_status = "✅ Response Complete"
+        # ============ Cost Estimate ============
+        # Stored as public keys so they travel with the usage dict: OpenWebUI
+        # renders every key of `message.usage` in the message info tooltip and
+        # persists the dict for the analytics page. Absent (not 0) for models
+        # with no known rate card.
+        if include_usage and total_usage and getattr(__user__["valves"], "SHOW_COST", True):
+            cost_breakdown = self._model_pricing().breakdown(body["model"].split("/")[-1], total_usage)
+            if cost_breakdown is not None:
+                total_usage["cost_usd"] = round(sum(cost_breakdown.values()), 6)
+                total_usage["cost_breakdown_usd"] = cost_breakdown
+
         # ============ Token Count Display ============
         show_token_setting = __user__["valves"].SHOW_TOKEN_COUNT
         if include_usage and show_token_setting != "Off" and total_usage and not is_internal:
@@ -10315,6 +10549,11 @@ class Pipe:
                 # me": the share of billed input served from cache at 0.1x.
                 if billed_input:
                     final_status += f" | ⚡ {cache_read / billed_input * 100:.0f}% cached"
+
+            # Estimated list-price cost of the whole turn (all calls). Silently
+            # absent for models with no known rate card rather than showing $0.
+            if "cost_usd" in total_usage:
+                final_status += f" | 💵 ≈{ModelPricing.format_usd(total_usage['cost_usd'])}"
 
         # Consolidate: emit a final replace with the complete message so OpenWebUI
         # has the authoritative content (replaces any partial delta/replace state).

--- a/helpers/build_anthropic_pipe.py
+++ b/helpers/build_anthropic_pipe.py
@@ -47,6 +47,7 @@ STREAM_SOURCES = [
     ("response.code_execution_results", SRC_DIR / "response" / "code_execution_results.py"),
     ("response.web_tool_results", SRC_DIR / "response" / "web_tool_results.py"),
     ("response.internal_tool_results", SRC_DIR / "response" / "internal_tool_results.py"),
+    ("shared.pricing", SRC_DIR / "shared" / "pricing.py"),
 ]
 
 

--- a/src/anthropic_pipe/pipe_orchestrator.py
+++ b/src/anthropic_pipe/pipe_orchestrator.py
@@ -356,6 +356,7 @@ class PipeOrchestratorMethods:
                 tool_loop_iteration += 1
                 # Reset per-iteration state
                 stream_output_tokens = 0
+                stream_web_search_requests = 0
 
                 try:
                     stream_event_counts = {}  # Track event types for diagnostics#
@@ -495,6 +496,20 @@ class PipeOrchestratorMethods:
                                             total_usage.get("input_tokens", 0)
                                             + total_usage.get("output_tokens", 0)
                                         )
+                                        # Web searches are billed per request
+                                        # ($10/1k). Like output_tokens, the
+                                        # count is cumulative within one API
+                                        # call, so accumulate the delta.
+                                        server_tool_use = getattr(usage, "server_tool_use", None)
+                                        current_searches = (
+                                            getattr(server_tool_use, "web_search_requests", 0) or 0
+                                        ) if server_tool_use else 0
+                                        total_usage["_web_search_requests"] = (
+                                            total_usage.get("_web_search_requests", 0)
+                                            + (current_searches - stream_web_search_requests)
+                                        )
+                                        stream_web_search_requests = current_searches
+                                        ModelPricing.record_billing_modifiers(usage, total_usage)
                                 delta = getattr(event, "delta", None)
                                 code_execution_container_id = getattr(delta, "container", None)
                                 if code_execution_container_id:
@@ -1176,6 +1191,17 @@ class PipeOrchestratorMethods:
         # ---------------------------------------------------------
 
         final_status = "✅ Response Complete"
+        # ============ Cost Estimate ============
+        # Stored as public keys so they travel with the usage dict: OpenWebUI
+        # renders every key of `message.usage` in the message info tooltip and
+        # persists the dict for the analytics page. Absent (not 0) for models
+        # with no known rate card.
+        if include_usage and total_usage and getattr(__user__["valves"], "SHOW_COST", True):
+            cost_breakdown = self._model_pricing().breakdown(body["model"].split("/")[-1], total_usage)
+            if cost_breakdown is not None:
+                total_usage["cost_usd"] = round(sum(cost_breakdown.values()), 6)
+                total_usage["cost_breakdown_usd"] = cost_breakdown
+
         # ============ Token Count Display ============
         show_token_setting = __user__["valves"].SHOW_TOKEN_COUNT
         if include_usage and show_token_setting != "Off" and total_usage and not is_internal:
@@ -1229,6 +1255,11 @@ class PipeOrchestratorMethods:
                 # me": the share of billed input served from cache at 0.1x.
                 if billed_input:
                     final_status += f" | ⚡ {cache_read / billed_input * 100:.0f}% cached"
+
+            # Estimated list-price cost of the whole turn (all calls). Silently
+            # absent for models with no known rate card rather than showing $0.
+            if "cost_usd" in total_usage:
+                final_status += f" | 💵 ≈{ModelPricing.format_usd(total_usage['cost_usd'])}"
 
         # Consolidate: emit a final replace with the complete message so OpenWebUI
         # has the authoritative content (replaces any partial delta/replace state).

--- a/src/anthropic_pipe/pipe_template.py
+++ b/src/anthropic_pipe/pipe_template.py
@@ -4,7 +4,7 @@ id: anthropic_new
 author: Podden (https://github.com/Podden/)
 github: https://github.com/Podden/openwebui_anthropic_api_manifold_pipe
 original_author: Balaxxe (Updated by nbellochi)
-version: 0.9.27
+version: 0.9.28
 license: MIT
 requirements: pydantic>=2.0.0, anthropic>=0.121.0, pillow-heif>=0.18.0
 environment_variables:
@@ -38,6 +38,10 @@ Supports:
 - Server-side fallback on safety refusals
 
 Changelog:
+v0.9.28
+- Added an estimated USD cost per turn (new SHOW_COST user valve): reported as `cost_usd` plus a per-component `cost_breakdown_usd` in the message usage, so it shows in the message info tooltip and is persisted for analytics, and appended to the SHOW_TOKEN_COUNT status line. Anthropic exposes no pricing via the API, so prices come from a built-in list-price table; admins can patch it without a release via the new MODEL_PRICING_OVERRIDES valve (JSON, USD per MTok)
+- The estimate follows the bill: cache writes are split 5m/1h from usage.cache_creation, fast mode and US data residency are detected from the response usage, and web searches are added at $10 per 1,000
+
 v0.9.27
 - Fixed model display names being lost while the model list is served from cache: the cached entries were built without the stored `_display_name`, so the picker fell back to raw ids for the whole cache TTL (#47, reported by @clang13)
 - Fixed a follow-up request 400 ("tool use found without a corresponding tool_result block") after a turn with several Anthropic-hosted code-execution calls: the stored carriers interleave, and replaying them in document order separated a server_tool_use from its result. Results are now pulled forward next to their tool_use (#40, by @JaWoDigiB)
@@ -1143,6 +1147,9 @@ class PipeRequestContext:
 # BEGIN GENERATED SECTION: anthropic_pipe.response.internal_tool_results
 # END GENERATED SECTION: anthropic_pipe.response.internal_tool_results
 
+# BEGIN GENERATED SECTION: anthropic_pipe.shared.pricing
+# END GENERATED SECTION: anthropic_pipe.shared.pricing
+
 
 
 
@@ -1479,6 +1486,16 @@ class Pipe:
             "Changing the API key, base URL, workspace or ENABLED_MODELS always "
             "refreshes immediately, regardless of this setting.",
         )
+        MODEL_PRICING_OVERRIDES: str = Field(
+            default="",
+            description="JSON patch for the built-in price table used by the SHOW_COST estimate, in USD per "
+            "million tokens, keyed by model id. Keys: input, output, cache_write_5m, cache_write_1h, "
+            "cache_read, fast_input, fast_output; omitted cache rates derive from `input` at Anthropic's "
+            "standard multipliers (1.25x / 2x / 0.1x). Example: "
+            '{"claude-sonnet-5": {"input": 3, "output": 15}, "my-proxy-model": {"input": 1, "output": 5}}. '
+            "Anthropic does not publish prices through the API, so this is how to track price changes "
+            "or a negotiated rate without waiting for a pipe release.",
+        )
 
     class UserValves(BaseModel):
         ANTHROPIC_API_KEY: EncryptedStr = Field(
@@ -1547,6 +1564,15 @@ class Pipe:
         SHOW_TOKEN_COUNT: Literal["Off", "On", "With Cache"] = Field(
             default="Off",
             description="Show context window progress after each response. 'With Cache' also shows cache read/write tokens.",
+        )
+        SHOW_COST: bool = Field(
+            default=True,
+            description="Report the estimated USD cost of the turn as `cost_usd` plus a per-component "
+            "`cost_breakdown_usd` (input, output, cache writes/reads, web search) in the message usage "
+            "(visible in the message info tooltip and persisted for analytics) and, when SHOW_TOKEN_COUNT "
+            "is on, in the status line. Based on Anthropic list prices for the model, including cache "
+            "writes/reads, fast mode, US data residency and web searches; negotiated or third-party-proxy "
+            "rates are not known to the pipe unless the admin sets MODEL_PRICING_OVERRIDES.",
         )
         WEB_SEARCH_MAX_USES: int = Field(
             default=5,

--- a/src/anthropic_pipe/response/runtime.py
+++ b/src/anthropic_pipe/response/runtime.py
@@ -50,6 +50,21 @@ class PipeStreamRuntimeSupportMethods:
             # continuations (server tools such as web_search) and retries.
             total_usage["cache_creation_input_tokens"] += cache_creation_input_tokens
             total_usage["cache_read_input_tokens"] += cache_read_input_tokens
+            # 5m and 1h writes are billed at 1.25x and 2x respectively, so the
+            # cost estimate needs the split. The API reports it in
+            # `cache_creation`; without it, attribute the whole write to the
+            # configured TTL (loses precision only when the tools/system TTL
+            # differs from the messages TTL).
+            breakdown = getattr(usage, "cache_creation", None)
+            write_5m = getattr(breakdown, "ephemeral_5m_input_tokens", None) if breakdown else None
+            write_1h = getattr(breakdown, "ephemeral_1h_input_tokens", None) if breakdown else None
+            if write_5m is None and write_1h is None:
+                if self.valves.CACHE_TTL == "1 hour":
+                    write_1h = cache_creation_input_tokens
+                else:
+                    write_5m = cache_creation_input_tokens
+            total_usage["_cache_write_5m"] = total_usage.get("_cache_write_5m", 0) + (write_5m or 0)
+            total_usage["_cache_write_1h"] = total_usage.get("_cache_write_1h", 0) + (write_1h or 0)
             logger.debug(
                 f" Usage stats: input={input_tokens}, output={current_output_tokens}, "
                 f"cache_creation={cache_creation_input_tokens}, cache_read={cache_read_input_tokens}"
@@ -60,6 +75,7 @@ class PipeStreamRuntimeSupportMethods:
             logger.debug(f" Usage stats: input={input_tokens}, output={current_output_tokens}")
 
         total_usage["_calls"] = total_usage.get("_calls", 0) + 1
+        ModelPricing.record_billing_modifiers(usage, total_usage)
 
         # Two different questions, deliberately kept apart:
         #

--- a/src/anthropic_pipe/shared/models.py
+++ b/src/anthropic_pipe/shared/models.py
@@ -92,6 +92,10 @@ class PipeModelSupportMethods:
         info.update(overrides)
         return info
 
+    def _model_pricing(self) -> "ModelPricing":
+        """Rate card for this pipe, with the admin's MODEL_PRICING_OVERRIDES applied."""
+        return ModelPricing(getattr(self.valves, "MODEL_PRICING_OVERRIDES", "") or "")
+
     def _model_cache_signature(self) -> str:
         """Fingerprint of the settings the model list depends on.
 

--- a/src/anthropic_pipe/shared/pricing.py
+++ b/src/anthropic_pipe/shared/pricing.py
@@ -1,0 +1,201 @@
+"""Compiled module-level section: Anthropic list prices and turn cost estimation."""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ModelPricing:
+    # Rate card in USD per million tokens, keyed by base (suffix-stripped) id.
+    # Source: platform.claude.com/docs/en/about-claude/pricing (verified
+    # 2026-09-02). The API does not expose pricing anywhere (/v1/models carries
+    # capabilities and limits only), so this table is the only source and the
+    # MODEL_PRICING_OVERRIDES valve is how admins patch it between releases.
+    #
+    # Only `input` and `output` are mandatory. The cache rates default to
+    # Anthropic's standard multipliers on the input price and are spelled out
+    # only where a model deviates. `fast_input` / `fast_output` are the
+    # fast-mode rates for the models that offer it.
+    RATES = {
+        # Cache reads on the 5.1 generation are 0.025x instead of 0.1x.
+        "claude-fable-5-1": {"input": 10.0, "output": 50.0, "cache_read": 0.25},
+        "claude-mythos-5-1": {"input": 10.0, "output": 50.0, "cache_read": 0.25},
+        "claude-fable-5": {"input": 10.0, "output": 50.0},
+        "claude-mythos-5": {"input": 10.0, "output": 50.0},
+        "claude-opus-5": {"input": 5.0, "output": 25.0, "fast_input": 10.0, "fast_output": 50.0},
+        "claude-opus-4-8": {"input": 5.0, "output": 25.0, "fast_input": 10.0, "fast_output": 50.0},
+        "claude-opus-4-7": {"input": 5.0, "output": 25.0},
+        "claude-opus-4-6": {"input": 5.0, "output": 25.0},
+        "claude-opus-4-5": {"input": 5.0, "output": 25.0},
+        "claude-sonnet-5": {"input": 2.0, "output": 10.0},
+        "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
+        "claude-sonnet-4-5": {"input": 3.0, "output": 15.0},
+        "claude-haiku-4-5": {"input": 1.0, "output": 5.0},
+        # Retired on the Claude API but still served by Bedrock / Google Cloud
+        # proxies. Haiku 3.5 is listed under both id orderings Anthropic used.
+        "claude-opus-4-1": {"input": 15.0, "output": 75.0},
+        "claude-opus-4": {"input": 15.0, "output": 75.0},
+        "claude-sonnet-4": {"input": 3.0, "output": 15.0},
+        "claude-haiku-3-5": {"input": 0.8, "output": 4.0},
+        "claude-3-5-haiku": {"input": 0.8, "output": 4.0},
+    }
+
+    # Multipliers relative to the base input price.
+    CACHE_WRITE_5M_MULTIPLIER = 1.25
+    CACHE_WRITE_1H_MULTIPLIER = 2.0
+    CACHE_READ_MULTIPLIER = 0.1
+    # `inference_geo: "us"` applies to every token category.
+    US_RESIDENCY_MULTIPLIER = 1.1
+    # Web search is billed per request on top of tokens ($10 per 1,000).
+    # Web fetch and code execution alongside web tools are free.
+    WEB_SEARCH_REQUEST_USD = 0.01
+
+    RATE_KEYS = (
+        "input",
+        "output",
+        "cache_write_5m",
+        "cache_write_1h",
+        "cache_read",
+        "fast_input",
+        "fast_output",
+    )
+
+    def __init__(self, overrides_json: str = ""):
+        self._overrides = self._parse_overrides(overrides_json)
+
+    @classmethod
+    def _parse_overrides(cls, raw: str) -> dict:
+        """Parse the MODEL_PRICING_OVERRIDES valve; a broken value is ignored, not fatal."""
+        raw = (raw or "").strip()
+        if not raw:
+            return {}
+        try:
+            overrides = json.loads(raw)
+            if not isinstance(overrides, dict):
+                raise ValueError("top level must be an object keyed by model id")
+            parsed: dict = {}
+            for model_id, patch in overrides.items():
+                if not isinstance(patch, dict):
+                    raise ValueError(f"{model_id!r}: expected an object of rates")
+                parsed[model_id] = {
+                    k: float(v) for k, v in patch.items() if k in cls.RATE_KEYS and v is not None
+                }
+            return parsed
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Ignoring MODEL_PRICING_OVERRIDES: {e}")
+            return {}
+
+    @staticmethod
+    def _normalize(model_name: str) -> str:
+        # Endpoints without aliases hand out dated ids ("claude-opus-5-20260301").
+        return re.sub(r"-\d{8}$", "", model_name)
+
+    def rates_for(self, model_name: str) -> Optional[dict]:
+        """Resolve the rate card for a model, or None if unknown.
+
+        Built-in RATES first, then the admin overrides merged on top per key, so
+        an override may touch a single rate or add a model the table has never
+        heard of. Missing cache rates are derived from `input` *after* the
+        merge, so overriding `input` alone keeps the cache rates consistent.
+        """
+        normalized = self._normalize(model_name)
+        base = self.RATES.get(model_name) or self.RATES.get(normalized)
+        rates: dict = dict(base) if base else {}
+        patch = self._overrides.get(model_name) or self._overrides.get(normalized)
+        if patch:
+            rates.update(patch)
+
+        if "input" not in rates or "output" not in rates:
+            return None
+        rates.setdefault("cache_write_5m", rates["input"] * self.CACHE_WRITE_5M_MULTIPLIER)
+        rates.setdefault("cache_write_1h", rates["input"] * self.CACHE_WRITE_1H_MULTIPLIER)
+        rates.setdefault("cache_read", rates["input"] * self.CACHE_READ_MULTIPLIER)
+        return rates
+
+    @staticmethod
+    def record_billing_modifiers(usage: Any, total_usage: dict) -> None:
+        """Note the response-reported billing modifiers on the turn's usage tally.
+
+        Read from the response rather than from the valves that requested them:
+        `speed: fast` on a model without fast mode runs (and bills) at standard
+        speed, and only the API knows which geo actually served the call. Both
+        are request-level settings, so one flag for the whole turn is exact.
+        """
+        if not usage:
+            return
+        if getattr(usage, "speed", None) == "fast":
+            total_usage["_speed_fast"] = 1
+        if getattr(usage, "inference_geo", None) == "us":
+            total_usage["_geo_us"] = 1
+
+    def breakdown(self, model_name: str, total_usage: dict) -> Optional[dict]:
+        """Per-component USD cost of a whole turn, or None if the model's rates are unknown.
+
+        Keys: input, output, cache_write_5m, cache_write_1h, cache_read,
+        web_search -- only the components that actually cost something, so
+        the usage tooltip stays short on a plain turn. Modifiers are baked into
+        the token components, mirroring Anthropic's stacking rules: fast mode
+        replaces the base input/output rates and the cache multipliers apply on
+        top of it; the US data-residency multiplier applies to every token
+        category; web searches are a flat per-request fee that no multiplier
+        touches.
+        """
+        rates = self.rates_for(model_name)
+        if not rates:
+            return None
+
+        input_rate = rates["input"]
+        output_rate = rates["output"]
+        write_5m_rate = rates["cache_write_5m"]
+        write_1h_rate = rates["cache_write_1h"]
+        read_rate = rates["cache_read"]
+        if total_usage.get("_speed_fast") and "fast_input" in rates and "fast_output" in rates:
+            scale = rates["fast_input"] / input_rate if input_rate else 1.0
+            input_rate = rates["fast_input"]
+            output_rate = rates["fast_output"]
+            write_5m_rate *= scale
+            write_1h_rate *= scale
+            read_rate *= scale
+
+        # Cache writes split by TTL when the API reported the breakdown; the
+        # undifferentiated counter is the fallback for endpoints that do not.
+        write_5m = total_usage.get("_cache_write_5m", 0)
+        write_1h = total_usage.get("_cache_write_1h", 0)
+        if not write_5m and not write_1h:
+            write_5m = total_usage.get("cache_creation_input_tokens", 0)
+
+        geo = self.US_RESIDENCY_MULTIPLIER if total_usage.get("_geo_us") else 1.0
+        token_components = {
+            "input": total_usage.get("input_tokens", 0) * input_rate,
+            "output": total_usage.get("output_tokens", 0) * output_rate,
+            "cache_write_5m": write_5m * write_5m_rate,
+            "cache_write_1h": write_1h * write_1h_rate,
+            "cache_read": total_usage.get("cache_read_input_tokens", 0) * read_rate,
+        }
+        components = {
+            name: amount * geo / 1_000_000 for name, amount in token_components.items()
+        }
+        components["web_search"] = (
+            total_usage.get("_web_search_requests", 0) * self.WEB_SEARCH_REQUEST_USD
+        )
+        return {name: round(amount, 6) for name, amount in components.items() if amount}
+
+    def estimate(self, model_name: str, total_usage: dict) -> Optional[float]:
+        """Estimate the USD list price of a whole turn, or None if the model's rates are unknown."""
+        components = self.breakdown(model_name, total_usage)
+        if components is None:
+            return None
+        return round(sum(components.values()), 6)
+
+    @staticmethod
+    def format_usd(cost: float) -> str:
+        """Format a cost so sub-cent turns stay legible without padding dollar turns."""
+        if cost >= 1:
+            return f"${cost:.2f}"
+        if cost >= 0.01:
+            return f"${cost:.3f}"
+        return f"${cost:.4f}"


### PR DESCRIPTION
Anthropic exposes no pricing through the API (/v1/models carries only capabilities and limits), so prices come from a hand-maintained list-price table in a new standalone ModelPricing class, patchable via the admin MODEL_PRICING_OVERRIDES valve without a release.

The estimate follows the actual bill: cache writes are split 5m/1h from usage.cache_creation, fast mode and US data residency are read from the response usage rather than the valves that requested them, and web searches are added at $10 per 1,000.

Reported as `cost_usd` plus a per-component `cost_breakdown_usd` in the message usage (message info tooltip, persisted for analytics) and, when SHOW_TOKEN_COUNT is on, appended to the status line. New SHOW_COST user valve (default on). Bumps pipe to 0.9.28.